### PR TITLE
Update openwrt.json

### DIFF
--- a/OpenWRT/openwrt.json
+++ b/OpenWRT/openwrt.json
@@ -1208,7 +1208,7 @@
           "value": "null"
         }
       ],
-      "valueName": "total"
+      "valueName": "current"
     },
     {
       "cacheTimeout": null,
@@ -1222,7 +1222,7 @@
       "datasource": "${DS_PROMETHEUS}",
       "decimals": 2,
       "description": "Total NAT traffic (WAN)",
-      "format": "bits",
+      "format": "bytes",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,

--- a/OpenWRT/openwrt.json
+++ b/OpenWRT/openwrt.json
@@ -5136,13 +5136,13 @@
       "interval": "5m",
       "legend": {
         "alignAsTable": true,
-        "avg": true,
-        "current": false,
+        "avg": false,
+        "current": true,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,
@@ -5225,13 +5225,13 @@
       "interval": "5m",
       "legend": {
         "alignAsTable": true,
-        "avg": true,
-        "current": false,
+        "avg": false,
+        "current": true,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,


### PR DESCRIPTION
- switch "Total NAT traffic (WAN)" from "bits" to "bytes"
- change "valueName" for "Total Network Traffic" to "current" as it already is a total value (would otherwise produce bogus/exceeding results due to "sum" calculation being used when left at "total")
- change network "Transmit Bytes Total" and "Receive Bytes Total" to only show current values, as it already is a total value