### PR TITLE
fix: Set "Total Network Traffic" to "instant"; avoid summing sums

### DIFF
--- a/OpenWRT/openwrt.json
+++ b/OpenWRT/openwrt.json
@@ -1192,6 +1192,7 @@
       "targets": [
         {
           "expr": "(sum(node_network_transmit_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}) + sum(node_network_receive_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}))",
+          "instant": true,
           "intervalFactor": 1,
           "refId": "A",
           "step": 900


### PR DESCRIPTION
If this is not set, the Total Network Traffic summary item will
continuously increase with every scrape (as though every total traffic count was all new traffic since the last scrape).

Small, clumsy fix. This dashboard is already pretty great: ideally we can manicure it some more and make it a spectacular drop-in.