### PR TITLE
ignore counter resets

### DIFF
--- a/OpenWRT/openwrt.json
+++ b/OpenWRT/openwrt.json
@@ -5175,7 +5175,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "expr": "node_network_transmit_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}/1024/1024",
+          "expr": "increase(node_network_transmit_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}[100y])/1024/1024",
           "legendFormat": "{{device}}",
           "refId": "A"
         }
@@ -5264,7 +5264,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "expr": "node_network_receive_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}/1024/1024",
+          "expr": "increase(node_network_receive_bytes_total{instance=~\"$node:$port\",job=~\"$job\"}[100y])/1024/1024",
           "legendFormat": "{{device}}",
           "refId": "A"
         }
@@ -5612,7 +5612,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_network_transmit_packets_total{instance=~\"$node:$port\",job=~\"$job\"}",
+          "expr": "increase(node_network_transmit_packets_total{instance=~\"$node:$port\",job=~\"$job\"}[100y])",
           "legendFormat": "{{device}}",
           "refId": "A"
         }
@@ -5701,7 +5701,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_network_receive_packets_total{instance=~\"$node:$port\",job=~\"$job\"}",
+          "expr": "increase(node_network_receive_packets_total{instance=~\"$node:$port\",job=~\"$job\"}[100y])",
           "legendFormat": "{{device}}",
           "refId": "A"
         }


### PR DESCRIPTION
after reboot, the traffic data starts at 0. This change ignores the counter resets and sums the values properly. 100year Look back window is needed to have a working graph also if zoomed in / left side of graph is not 0.

Before:
![image](https://github.com/try2codesecure/grafana_dashboards/assets/1613368/34e0eac9-9a24-4ae9-8bfe-c26f41031262)

After:
![image](https://github.com/try2codesecure/grafana_dashboards/assets/1613368/5029ef2c-4559-4333-8013-8162f11db69f)
